### PR TITLE
fix: api.Version is always `(devel)`

### DIFF
--- a/api/version.go
+++ b/api/version.go
@@ -14,7 +14,6 @@ var (
 
 func init() {
 	if i, ok := debug.ReadBuildInfo(); ok {
-		Version = i.Main.Version
 		if vcsv, ok := lo.Find(i.Settings, func(s debug.BuildSetting) bool {
 			return s.Key == "vcs.revision"
 		}); ok {


### PR DESCRIPTION
Do not override api.Version with a version from BuildInfo
