### PR TITLE
feat: open specific target(homepage, repository, registry) by -b flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ View package documentation in terminal:
 ```bash
 miru [package]                    # Display documentation in man-like interface
 miru [package] -b                 # Open documentation in browser
+miru [package] -b=[target]                 # Open specific documentation in browser
 miru [lang] [package]             # Specify package language explicitly
 miru [package] --lang [lang]      # Specify package language with flag
 miru [package] -o json           # Output metadata in JSON format

--- a/cli/flag.go
+++ b/cli/flag.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type browseTargetFlag struct {
+	IsSet bool
+	Value string
+}
+
+// String implements pflag.Value.
+func (s *browseTargetFlag) String() string {
+	return s.Value
+}
+
+func (s *browseTargetFlag) Set(value string) error {
+	s.Value = value
+	s.IsSet = true
+	return nil
+}
+
+func (s *browseTargetFlag) Type() string {
+	return "target"
+}
+
+var _ pflag.Value = &browseTargetFlag{}

--- a/cli/run.go
+++ b/cli/run.go
@@ -250,6 +250,7 @@ func displayDocumentation(i api.InitialQuery, load loadFunc, logger io.Writer) e
 // openInBrowser opens the documentation in the default browser
 func openInBrowser(i api.InitialQuery, r api.Result, target string, logger io.Writer) error {
 	var u *url.URL
+	target = strings.ToLower(target)
 	switch target {
 	case "h", "homepage":
 		u = r.GetHomepage()


### PR DESCRIPTION
with flag `-b=<target>`, open specific URL if available.
fix #53

## NOTE

**`=` is required!**

ref: https://github.com/spf13/pflag/issues/321

```sh
$ miru npm express -b h # will not work

$ miru npm express -b=h # will work
```
