### PR TITLE
feat: Add Nix flake for installation

### DIFF
--- a/.github/workflows/default-branch.yml
+++ b/.github/workflows/default-branch.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   tagpr:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: "false"
+      - uses: cachix/install-nix-action@1ca7d21a94afc7c957383a2d217460d980de4934 # v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: aquaproj/aqua-installer@e2d0136abcf70b7a2f6f505720640750557c4b33 # v3.1.1
         with:
           aqua_version: v2.43.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,6 @@ jobs:
     needs:
       - test
       - nix-build
-    if: failure()
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     steps:
       - run: exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,11 +29,24 @@ jobs:
       - name: go test
         run: go test ./...
 
+  nix-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: cachix/install-nix-action@1ca7d21a94afc7c957383a2d217460d980de4934 # v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix build .#miru
+
   status-check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
       - test
+      - nix-build
     if: failure()
     steps:
       - run: exit 1

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ wget https://github.com/ka2n/miru/releases/download/v${MIRU_VERSION}/miru_${MIRU
 apk add --allow-untrusted ./miru_$MIRU_VERSION-1_amd64.apk
 ```
 
+#### Nix
+
+```bash
+# Run directly
+nix run github:ka2n/miru
+
+# Install to profile
+nix profile install github:ka2n/miru
+```
+
 #### Debian/Ubuntu
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773231277,
+        "narHash": "sha256-Xy3WEpUAbpsz8ydgvVAQAGGB/WB+8cNA5cshiL0McTI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "75690239f08f885ca9b0267580101f60d10fbe62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "miru - A CLI tool for viewing package documentation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "0.0.21";
+      in
+      {
+        packages = {
+          miru = pkgs.buildGoModule {
+            pname = "miru";
+            inherit version;
+            src = ./.;
+            vendorHash = "sha256-Q2n0TwPMYwC6lbQfSw9xgM2eMs0HLcKE9uXh7Tt7RG0=";
+            subPackages = [ "cmd/miru" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+            ];
+
+            meta = {
+              description = "A CLI tool for viewing package documentation";
+              homepage = "https://github.com/ka2n/miru";
+              mainProgram = "miru";
+            };
+          };
+
+          default = self.packages.${system}.miru;
+        };
+      }
+    );
+}

--- a/justfile
+++ b/justfile
@@ -16,8 +16,24 @@ lint:
     actionlint
     goreleaser check
 
+[group('Nix')]
+update-vendor-hash:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    sed -i "s|vendorHash = \"sha256-[^\"]*\";|vendorHash = \"${FAKE}\";|" flake.nix
+    HASH=$(nix build .#miru 2>&1 | sed -n 's/.*got: *\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' || true)
+    if [ -z "$HASH" ]; then
+        echo "Error: failed to get vendorHash" >&2
+        sed -i "s|${FAKE}|sha256-TODO|" flake.nix
+        exit 1
+    fi
+    sed -i "s|${FAKE}|${HASH}|" flake.nix
+    echo "Updated vendorHash to: ${HASH}"
+
 [group('Release')]
 prerelease:
     go mod tidy
     gocredits --skip-missing -w .
     git add CREDITS
+    if command -v nix >/dev/null 2>&1; then just update-vendor-hash && git add flake.nix; fi


### PR DESCRIPTION
## Summary

- Add `flake.nix` to support installation via `nix run github:ka2n/miru` / `nix profile install github:ka2n/miru`
- Add `just update-vendor-hash` recipe to auto-update vendorHash in flake.nix after dependency changes
- Run `update-vendor-hash` automatically in `just prerelease` when nix is available
- Add `nix-build` CI job on PRs to catch vendorHash mismatches before merge
- Install Nix in tagpr job so vendorHash is auto-updated during release

🤖 Generated with [Claude Code](https://claude.com/claude-code)