### PR TITLE
feat: add GitHub repository metadata to JSON and markdown output

### DIFF
--- a/api/result.go
+++ b/api/result.go
@@ -13,6 +13,9 @@ type Result struct {
 	InitialQueryURL  *url.URL
 	InitialQueryType source.Type
 	Links            []Link
+
+	// Metadata contains repository metadata (e.g., stars, license, last updated)
+	Metadata map[string]any
 }
 
 type Link struct {
@@ -24,6 +27,7 @@ type Link struct {
 func CreateResult(inv *Investigation) Result {
 	var result Result
 	result.Links = make([]Link, 0, len(inv.CollectedData))
+	result.Metadata = make(map[string]any)
 
 	// Check if README content is available in the collected data
 	for _, data := range inv.CollectedData {
@@ -40,6 +44,11 @@ func CreateResult(inv *Investigation) Result {
 			Type: data.Source.Type,
 			URL:  data.BrowserURL,
 		})
+
+		// Merge metadata from all sources
+		for k, v := range data.Metadata {
+			result.Metadata[k] = v
+		}
 	}
 
 	// Get data from the source type of the initial query

--- a/api/sourceimpl/crates.go
+++ b/api/sourceimpl/crates.go
@@ -41,17 +41,17 @@ type cratesVersionInfo struct {
 
 // fetchCratesIO fetches the README content from crates.io
 // Returns the content, related sources, and any error
-func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Get package information from crates.io API
 	url := fmt.Sprintf("https://crates.io/api/v1/crates/%s?include=default_version", pkgPath)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return "", nil, failure.New(ErrRepositoryNotFound,
+		return "", nil, nil, failure.New(ErrRepositoryNotFound,
 			failure.Message("Failed to fetch package information from crates.io"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -65,7 +65,7 @@ func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
 		Versions []cratesVersionInfo `json:"versions"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	info := response.Crate
@@ -80,7 +80,7 @@ func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
 	}
 
 	if defaultVersion == nil || defaultVersion.ReadmePath == "" {
-		return "", nil, failure.New(ErrCratesREADMENotFound,
+		return "", nil, nil, failure.New(ErrCratesREADMENotFound,
 			failure.Message("README not found in package"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -91,12 +91,12 @@ func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
 	readmeURL := fmt.Sprintf("https://crates.io%s", defaultVersion.ReadmePath)
 	readmeResp, err := http.Get(readmeURL)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer readmeResp.Body.Close()
 
 	if readmeResp.StatusCode == http.StatusNotFound {
-		return "", nil, failure.New(ErrCratesREADMENotFound,
+		return "", nil, nil, failure.New(ErrCratesREADMENotFound,
 			failure.Message("README not found"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -108,14 +108,14 @@ func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
 	// Read HTML content
 	htmlContent, err := io.ReadAll(readmeResp.Body)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Convert HTML to Markdown
 	converter := md.NewConverter("", true, nil)
 	markdown, err := converter.ConvertString(string(htmlContent))
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Format the documentation text
@@ -212,7 +212,25 @@ func fetchCratesIO(pkgPath string) (string, []source.RelatedReference, error) {
 	docSources := extractRelatedSources(doc, pkgPath)
 	sources = append(sources, docSources...)
 
-	return doc, sources, nil
+	// Build result metadata
+	resultMeta := map[string]any{}
+	if info.Description != "" {
+		resultMeta["description"] = info.Description
+	}
+	if defaultVersion.License != "" {
+		resultMeta["license"] = defaultVersion.License
+	}
+	if info.DefaultVersion != "" {
+		resultMeta["version"] = info.DefaultVersion
+	}
+	if len(info.Categories) > 0 {
+		resultMeta["categories"] = info.Categories
+	}
+	if len(info.Keywords) > 0 {
+		resultMeta["keywords"] = info.Keywords
+	}
+
+	return doc, sources, resultMeta, nil
 }
 
 // Implementation of CratesIO Investigator
@@ -220,7 +238,7 @@ type CratesIOInvestigator struct{}
 
 func (i *CratesIOInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from crates.io
-	content, relatedSources, err := fetchCratesIO(packagePath)
+	content, relatedSources, metadata, err := fetchCratesIO(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -230,6 +248,7 @@ func (i *CratesIOInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: relatedSources,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/github.go
+++ b/api/sourceimpl/github.go
@@ -29,7 +29,23 @@ const (
 
 // githubRepoResponse represents the GitHub API response for repository information
 type githubRepoResponse struct {
-	Homepage string `json:"homepage"`
+	Homepage        string          `json:"homepage"`
+	Description     string          `json:"description"`
+	StargazersCount int             `json:"stargazers_count"`
+	ForksCount      int             `json:"forks_count"`
+	OpenIssuesCount int             `json:"open_issues_count"`
+	Archived        bool            `json:"archived"`
+	License         *githubLicense  `json:"license"`
+	Language        string          `json:"language"`
+	Topics          []string        `json:"topics"`
+	PushedAt        string          `json:"pushed_at"`
+	CreatedAt       string          `json:"created_at"`
+	DefaultBranch   string          `json:"default_branch"`
+}
+
+type githubLicense struct {
+	SPDXID string `json:"spdx_id"`
+	Name   string `json:"name"`
 }
 
 // githubContentsResponse represents the GitHub API response for repository contents
@@ -48,8 +64,8 @@ type githubContentResponse struct {
 }
 
 // fetchGitHub fetches the README content from a GitHub repository
-// Returns the content, related sources, and any error
-func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
+// Returns the content, related sources, metadata, and any error
+func fetchGitHub(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Strip ".*github.com/" prefix from package path
 	pos := strings.Index(pkgPath, "github.com/")
 	if pos != -1 {
@@ -64,7 +80,7 @@ func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
 
 	// Check if gh command exists
 	if _, err := exec.LookPath(ghCmd); err != nil {
-		return "", nil, failure.New(ErrGHCommandNotFound,
+		return "", nil, nil, failure.New(ErrGHCommandNotFound,
 			failure.Message(fmt.Sprintf("gh command not found at %s. Please install GitHub CLI: https://cli.github.com/ or set %s environment variable", ghCmd, EnvGHCommand)),
 			failure.Context{
 				"error": err.Error(),
@@ -76,7 +92,7 @@ func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
 	// Extract owner and repo from package path (already trimmed of github.com/)
 	parts := strings.Split(pkgPath, "/")
 	if len(parts) < 2 {
-		return "", nil, failure.New(ErrInvalidPackagePath,
+		return "", nil, nil, failure.New(ErrInvalidPackagePath,
 			failure.Message("Invalid GitHub package path"),
 			failure.Context{"path": pkgPath},
 		)
@@ -92,7 +108,7 @@ func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
 		repo = repo[:idx]
 	}
 	if repo == "" {
-		return "", nil, failure.New(ErrInvalidPackagePath,
+		return "", nil, nil, failure.New(ErrInvalidPackagePath,
 			failure.Message("Invalid GitHub package path"),
 			failure.Context{"path": pkgPath},
 		)
@@ -186,7 +202,7 @@ func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
 
 	// Wait for all goroutines to complete
 	if err := g.Wait(); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	// Combine all sources
@@ -213,7 +229,38 @@ func fetchGitHub(pkgPath string) (string, []source.RelatedReference, error) {
 		}
 	}
 
-	return docContent, sources, nil
+	// Build metadata from repository info
+	metadata := map[string]any{
+		"stars":       info.StargazersCount,
+		"forks":       info.ForksCount,
+		"open_issues": info.OpenIssuesCount,
+	}
+	if info.Archived {
+		metadata["archived"] = true
+	}
+	if info.Description != "" {
+		metadata["description"] = info.Description
+	}
+	if info.Language != "" {
+		metadata["language"] = info.Language
+	}
+	if info.PushedAt != "" {
+		metadata["pushed_at"] = info.PushedAt
+	}
+	if info.CreatedAt != "" {
+		metadata["created_at"] = info.CreatedAt
+	}
+	if info.DefaultBranch != "" {
+		metadata["default_branch"] = info.DefaultBranch
+	}
+	if info.License != nil && info.License.SPDXID != "" {
+		metadata["license"] = info.License.SPDXID
+	}
+	if len(info.Topics) > 0 {
+		metadata["topics"] = info.Topics
+	}
+
+	return docContent, sources, metadata, nil
 }
 
 func (c githubContentResponse) GetContent() (io.Reader, error) {
@@ -235,7 +282,7 @@ type GitHubInvestigator struct{}
 
 func (i *GitHubInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from GitHub
-	content, rel, err := fetchGitHub(packagePath)
+	content, rel, metadata, err := fetchGitHub(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -245,6 +292,7 @@ func (i *GitHubInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: rel,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/npm.go
+++ b/api/sourceimpl/npm.go
@@ -14,27 +14,31 @@ import (
 
 // npmPackageInfo represents the npm package information from registry
 type npmPackageInfo struct {
-	Readme     string `json:"readme"`
-	Homepage   string `json:"homepage"`
-	Repository struct {
+	Readme      string   `json:"readme"`
+	Homepage    string   `json:"homepage"`
+	Description string   `json:"description"`
+	License     any      `json:"license"`
+	Keywords    []string `json:"keywords"`
+	Repository  struct {
 		Type string `json:"type"`
 		URL  string `json:"url"`
 	} `json:"repository"`
+	DistTags map[string]string `json:"dist-tags"`
 }
 
 // fetchNPM fetches the README content from npm registry
 // Returns the content, related sources, and any error
-func fetchNPM(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchNPM(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Get package information from npm registry
 	url := fmt.Sprintf("https://registry.npmjs.org/%s", pkgPath)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, failure.New(ErrRepositoryNotFound,
+		return "", nil, nil, failure.New(ErrRepositoryNotFound,
 			failure.Message("Failed to fetch package information from npm registry"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -45,7 +49,7 @@ func fetchNPM(pkgPath string) (string, []source.RelatedReference, error) {
 	// Parse JSON response
 	var info npmPackageInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Extract related sources from content and API response
@@ -84,16 +88,38 @@ func fetchNPM(pkgPath string) (string, []source.RelatedReference, error) {
 	docSources := extractRelatedSources(info.Readme, pkgPath)
 	sources = append(sources, docSources...)
 
-	return info.Readme, sources, nil
+	// Build metadata
+	metadata := map[string]any{}
+	if info.Description != "" {
+		metadata["description"] = info.Description
+	}
+	if info.License != nil {
+		// license can be a string or an object with "type" field
+		switch v := info.License.(type) {
+		case string:
+			metadata["license"] = v
+		case map[string]any:
+			if t, ok := v["type"].(string); ok {
+				metadata["license"] = t
+			}
+		}
+	}
+	if len(info.Keywords) > 0 {
+		metadata["keywords"] = info.Keywords
+	}
+	if v, ok := info.DistTags["latest"]; ok {
+		metadata["version"] = v
+	}
+
+	return info.Readme, sources, metadata, nil
 }
 
 // Implementation of NPM Investigator
 type NPMInvestigator struct{}
 
 func (i *NPMInvestigator) Fetch(packagePath string) (source.Data, error) {
-
 	// Process to retrieve data from NPM
-	content, RelatedSources, err := fetchNPM(packagePath)
+	content, RelatedSources, metadata, err := fetchNPM(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -103,6 +129,7 @@ func (i *NPMInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: RelatedSources,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/packagist.go
+++ b/api/sourceimpl/packagist.go
@@ -36,17 +36,17 @@ type packagistPackageInfo struct {
 
 // fetchPackagist fetches the README content from Packagist registry
 // Returns the content, related sources, and any error
-func fetchPackagist(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchPackagist(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Get package information from Packagist API
 	url := fmt.Sprintf("https://packagist.org/packages/%s.json", pkgPath)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, failure.New(ErrRepositoryNotFound,
+		return "", nil, nil, failure.New(ErrRepositoryNotFound,
 			failure.Message("Failed to fetch package information from packagist.org"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -57,7 +57,7 @@ func fetchPackagist(pkgPath string) (string, []source.RelatedReference, error) {
 	// Parse JSON response
 	var info packagistPackageInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Packagist does not have a README file, but it has a description
@@ -72,7 +72,7 @@ func fetchPackagist(pkgPath string) (string, []source.RelatedReference, error) {
 
 		// If still no description, return an error
 		if info.Package.Description == "" {
-			return "", nil, failure.New(ErrPackagistREADMENotFound,
+			return "", nil, nil, failure.New(ErrPackagistREADMENotFound,
 				failure.Message("README not found in package"),
 				failure.Context{
 					"pkg": pkgPath,
@@ -131,7 +131,13 @@ func fetchPackagist(pkgPath string) (string, []source.RelatedReference, error) {
 	docSources := extractRelatedSources(info.Package.Description, pkgPath)
 	sources = append(sources, docSources...)
 
-	return info.Package.Description, sources, nil
+	// Build metadata
+	metadata := map[string]any{}
+	if info.Package.Description != "" {
+		metadata["description"] = info.Package.Description
+	}
+
+	return info.Package.Description, sources, metadata, nil
 }
 
 // Implementation of Packagist Investigator
@@ -139,7 +145,7 @@ type PackagistInvestigator struct{}
 
 func (i *PackagistInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from packagist.org
-	content, RelatedSources, err := fetchPackagist(packagePath)
+	content, RelatedSources, metadata, err := fetchPackagist(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -149,6 +155,7 @@ func (i *PackagistInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: RelatedSources,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/pkggodev.go
+++ b/api/sourceimpl/pkggodev.go
@@ -17,17 +17,18 @@ const (
 )
 
 // fetchPkgGoDev fetches the README file from pkg.go.dev or the source repository
-func fetchPkgGoDev(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchPkgGoDev(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// https://pkg.go.dev/cmd/go#hdr-Remote_import_paths
 	if strings.Contains(pkgPath, "github.com/") {
 		return fetchGitHub(pkgPath)
 	} else if strings.Contains(pkgPath, "gitlab.com/") {
-		return fetchGitlab(pkgPath)
+		content, sources, err := fetchGitlab(pkgPath)
+		return content, sources, nil, err
 	}
 
 	repo, home, err := detectGoMetadata(pkgPath, nil)
 	if repo == nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	// Get Readme content from the repository
@@ -40,10 +41,11 @@ func fetchPkgGoDev(pkgPath string) (string, []source.RelatedReference, error) {
 	if sourceRepoURL != nil {
 		var content string
 		var sources []source.RelatedReference
+		var metadata map[string]any
 		var err error
 
 		if strings.Contains(sourceRepoURL.String(), "github.com") {
-			content, sources, err = fetchGitHub(sourceRepoURL.String())
+			content, sources, metadata, err = fetchGitHub(sourceRepoURL.String())
 		} else if strings.Contains(sourceRepoURL.String(), "gitlab.com") {
 			content, sources, err = fetchGitlab(sourceRepoURL.String())
 		} else {
@@ -51,7 +53,7 @@ func fetchPkgGoDev(pkgPath string) (string, []source.RelatedReference, error) {
 		}
 
 		if err != nil {
-			return "", nil, err
+			return "", nil, nil, err
 		}
 
 		if home != nil {
@@ -79,10 +81,10 @@ func fetchPkgGoDev(pkgPath string) (string, []source.RelatedReference, error) {
 			From: "api",
 		})
 
-		return content, sources, nil
+		return content, sources, metadata, nil
 	}
 
-	return "", nil, failure.New(ErrPkgGoDevREADMENotFound,
+	return "", nil, nil, failure.New(ErrPkgGoDevREADMENotFound,
 		failure.Message("Package not found"),
 		failure.Context{
 			"pkg": pkgPath,
@@ -232,7 +234,7 @@ type GoPkgDevInvestigator struct{}
 
 func (i *GoPkgDevInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from pkg.go.dev
-	content, RelatedSources, err := fetchPkgGoDev(packagePath)
+	content, RelatedSources, metadata, err := fetchPkgGoDev(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -242,6 +244,7 @@ func (i *GoPkgDevInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: RelatedSources,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/pypi.go
+++ b/api/sourceimpl/pypi.go
@@ -23,12 +23,17 @@ type pypiPackageInfo struct {
 		ProjectURLs map[string]string `json:"project_urls"`
 		Description string            `json:"description"`
 		Homepage    string            `json:"home_page"`
+		Summary     string            `json:"summary"`
+		License     string            `json:"license"`
+		Version     string            `json:"version"`
+		Author      string            `json:"author"`
+		Keywords    string            `json:"keywords"`
 	} `json:"info"`
 }
 
 // fetchPyPI fetches the README content from PyPI registry
 // Returns the content, related sources, and any error
-func fetchPyPI(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchPyPI(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Extract only the package name (remove organization name if present)
 	pkgName := pkgPath
 	if idx := strings.LastIndex(pkgPath, "/"); idx != -1 {
@@ -39,12 +44,12 @@ func fetchPyPI(pkgPath string) (string, []source.RelatedReference, error) {
 	url := fmt.Sprintf("https://pypi.org/pypi/%s/json", pkgName)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, failure.New(ErrRepositoryNotFound,
+		return "", nil, nil, failure.New(ErrRepositoryNotFound,
 			failure.Message("Failed to fetch package information from pypi.org"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -55,12 +60,12 @@ func fetchPyPI(pkgPath string) (string, []source.RelatedReference, error) {
 	// Parse JSON response
 	var info pypiPackageInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Description is used as README
 	if info.Info.Description == "" {
-		return "", nil, failure.New(ErrPyPIREADMENotFound,
+		return "", nil, nil, failure.New(ErrPyPIREADMENotFound,
 			failure.Message("README not found in package"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -127,7 +132,25 @@ func fetchPyPI(pkgPath string) (string, []source.RelatedReference, error) {
 	docSources := extractRelatedSources(info.Info.Description, pkgPath)
 	sources = append(sources, docSources...)
 
-	return info.Info.Description, sources, nil
+	// Build metadata
+	metadata := map[string]any{}
+	if info.Info.Summary != "" {
+		metadata["description"] = info.Info.Summary
+	}
+	if info.Info.License != "" {
+		metadata["license"] = info.Info.License
+	}
+	if info.Info.Version != "" {
+		metadata["version"] = info.Info.Version
+	}
+	if info.Info.Author != "" {
+		metadata["authors"] = info.Info.Author
+	}
+	if info.Info.Keywords != "" {
+		metadata["keywords"] = strings.Split(info.Info.Keywords, ",")
+	}
+
+	return info.Info.Description, sources, metadata, nil
 }
 
 // Implementation of PyPI Investigator
@@ -135,7 +158,7 @@ type PyPIInvestigator struct{}
 
 func (i *PyPIInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from pypi.org
-	content, RelatedSources, err := fetchPyPI(packagePath)
+	content, RelatedSources, metadata, err := fetchPyPI(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -145,6 +168,7 @@ func (i *PyPIInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: RelatedSources,
 		BrowserURL:     browserURL,

--- a/api/sourceimpl/rubygems.go
+++ b/api/sourceimpl/rubygems.go
@@ -34,17 +34,17 @@ type rubyGemsPackageInfo struct {
 
 // fetchRubyGemsReadme fetches the package information from RubyGems API
 // Returns the formatted documentation and related sources
-func fetchRubyGemsReadme(pkgPath string) (string, []source.RelatedReference, error) {
+func fetchRubyGemsReadme(pkgPath string) (string, []source.RelatedReference, map[string]any, error) {
 	// Get package information from RubyGems API
 	url := fmt.Sprintf("https://rubygems.org/api/v1/gems/%s.json", pkgPath)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, failure.New(ErrRepositoryNotFound,
+		return "", nil, nil, failure.New(ErrRepositoryNotFound,
 			failure.Message("Failed to fetch package information from rubygems.org"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -53,7 +53,7 @@ func fetchRubyGemsReadme(pkgPath string) (string, []source.RelatedReference, err
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return "", nil, failure.New(ErrRubyGemsREADMENotFound,
+		return "", nil, nil, failure.New(ErrRubyGemsREADMENotFound,
 			failure.Message("Package not found"),
 			failure.Context{
 				"pkg": pkgPath,
@@ -64,7 +64,7 @@ func fetchRubyGemsReadme(pkgPath string) (string, []source.RelatedReference, err
 	// Parse JSON response
 	var info rubyGemsPackageInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return "", nil, failure.Wrap(err)
+		return "", nil, nil, failure.Wrap(err)
 	}
 
 	// Format the documentation text
@@ -119,7 +119,27 @@ func fetchRubyGemsReadme(pkgPath string) (string, []source.RelatedReference, err
 		}
 	}
 
-	return doc, uniqueSources, nil
+	// Build metadata
+	metadata := map[string]any{
+		"downloads": info.DownloadCount,
+	}
+	if info.Description != "" {
+		metadata["description"] = info.Description
+	}
+	if len(info.Licenses) > 0 {
+		metadata["license"] = strings.Join(info.Licenses, ", ")
+	}
+	if info.Version != "" {
+		metadata["version"] = info.Version
+	}
+	if info.Authors != "" {
+		metadata["authors"] = info.Authors
+	}
+	if info.Platform != "" {
+		metadata["platform"] = info.Platform
+	}
+
+	return doc, uniqueSources, metadata, nil
 }
 
 // formatRubyGemsDoc formats the RubyGems package information into a markdown document
@@ -176,7 +196,7 @@ type RubyGemsInvestigator struct{}
 
 func (i *RubyGemsInvestigator) Fetch(packagePath string) (source.Data, error) {
 	// Process to retrieve data from rubygems.org
-	content, RelatedSources, err := fetchRubyGemsReadme(packagePath)
+	content, RelatedSources, metadata, err := fetchRubyGemsReadme(packagePath)
 	if err != nil {
 		return source.Data{}, err
 	}
@@ -186,6 +206,7 @@ func (i *RubyGemsInvestigator) Fetch(packagePath string) (source.Data, error) {
 
 	return source.Data{
 		Contents:       map[string]string{"README.md": content},
+		Metadata:       metadata,
 		FetchedAt:      time.Now(),
 		RelatedSources: RelatedSources,
 		BrowserURL:     browserURL,

--- a/cli/run.go
+++ b/cli/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -239,7 +240,10 @@ func displayDocumentation(i api.InitialQuery, load loadFunc, logger io.Writer) e
 
 	// Check if stdout is a terminal
 	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-		// If not a terminal, print content directly to stdout
+		// If not a terminal, print content with YAML frontmatter
+		if err := writeFrontmatter(os.Stdout, r); err != nil {
+			return failure.Wrap(err)
+		}
 		fmt.Fprintln(os.Stdout, out)
 		return nil
 	}
@@ -291,13 +295,14 @@ func displayJSON(i api.InitialQuery, r api.Result, writer io.Writer) error {
 
 	// DocInfo represents the JSON output structure
 	type DocInfo struct {
-		Type       source.Type `json:"type"`
-		URL        string      `json:"url"`
-		Homepage   string      `json:"homepage,omitempty"`
-		Repository string      `json:"repository,omitempty"`
-		Registry   string      `json:"registry,omitempty"`
-		Document   string      `json:"document,omitempty"`
-		URLs       []strLink   `json:"urls"`
+		Type       source.Type    `json:"type"`
+		URL        string         `json:"url"`
+		Homepage   string         `json:"homepage,omitempty"`
+		Repository string         `json:"repository,omitempty"`
+		Registry   string         `json:"registry,omitempty"`
+		Document   string         `json:"document,omitempty"`
+		URLs       []strLink      `json:"urls"`
+		Metadata   map[string]any `json:"metadata,omitempty"`
 	}
 
 	var (
@@ -336,6 +341,11 @@ func displayJSON(i api.InitialQuery, r api.Result, writer io.Writer) error {
 		url = r.InitialQueryURL.String()
 	}
 
+	var metadata map[string]any
+	if len(r.Metadata) > 0 {
+		metadata = r.Metadata
+	}
+
 	info := DocInfo{
 		Type:       r.InitialQueryType,
 		URL:        url,
@@ -344,12 +354,59 @@ func displayJSON(i api.InitialQuery, r api.Result, writer io.Writer) error {
 		Registry:   registry,
 		Document:   docs,
 		URLs:       urls,
+		Metadata:   metadata,
 	}
 
 	enc := json.NewEncoder(writer)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(info); err != nil {
+		return failure.Wrap(err)
+	}
+	return nil
+}
+
+// writeFrontmatter writes YAML frontmatter containing metadata and selected URL fields to the writer.
+func writeFrontmatter(w io.Writer, r api.Result) error {
+	fm := make(map[string]any)
+
+	// Add URL information
+	if r.InitialQueryURL != nil {
+		fm["url"] = r.InitialQueryURL.String()
+	}
+	if u := r.GetRepository(); u != nil {
+		fm["repository"] = u.String()
+	}
+	if u := r.GetRegistry(); u != nil {
+		fm["registry"] = u.String()
+	}
+	if u := r.GetHomepage(); u != nil {
+		fm["homepage"] = u.String()
+	}
+
+	// Merge metadata (URL keys take precedence over metadata keys)
+	for k, v := range r.Metadata {
+		if _, exists := fm[k]; !exists {
+			fm[k] = v
+		}
+	}
+
+	if len(fm) == 0 {
+		return nil
+	}
+
+	data, err := yaml.Marshal(fm)
+	if err != nil {
+		return failure.Wrap(err)
+	}
+
+	if _, err := fmt.Fprintln(w, "---"); err != nil {
+		return failure.Wrap(err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return failure.Wrap(err)
+	}
+	if _, err := fmt.Fprintln(w, "---"); err != nil {
 		return failure.Wrap(err)
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -74,7 +75,6 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 tool github.com/k0kubun/pp/v3


### PR DESCRIPTION
## Summary

- Fetch GitHub repository metadata (stars, license, last pushed date, archived status, etc.) from the API
- Add `metadata` field to `-o json` output
- Write YAML frontmatter with metadata in non-TTY markdown output
- Enables evaluating repository health during library selection, not just documentation content

🤖 Generated with [Claude Code](https://claude.com/claude-code)